### PR TITLE
[fix]: sync common staging values - [feat]: add input to avoid syncing performance values

### DIFF
--- a/.github/actions/argocd-deployment/update-chart-values/action.yaml
+++ b/.github/actions/argocd-deployment/update-chart-values/action.yaml
@@ -9,6 +9,10 @@ inputs:
   branch_name:
     description: 'The name of the current Git branch.'
     required: true
+  deploy_on_performance:
+    description: 'Determines if the deployment in the ALL_ENV stage should occur in the performance environment. Defaults to "false".'
+    required: false
+    default: 'false'
   deploy_on_sandbox:
     description: 'Determines if the deployment in the ALL_ENV stage should occur in the sandbox environment. Defaults to "true".'
     required: false
@@ -59,6 +63,7 @@ runs:
       env:
         APP_NAME: ${{ inputs.app_name }}
         BRANCH_NAME: ${{ inputs.branch_name }}
+        DEPLOY_ON_PERFORMANCE: ${{ inputs.deploy_on_performance }}
         DEPLOY_ON_SANDBOX: ${{ inputs.deploy_on_sandbox }}
         ENV_TO_DEPLOY: ${{ inputs.env_to_deploy }}
         IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/actions/argocd-deployment/update-chart-values/entrypoint.sh
+++ b/.github/actions/argocd-deployment/update-chart-values/entrypoint.sh
@@ -82,14 +82,14 @@ if [[ "$ENV_TO_DEPLOY" == "ALL_ENV" ]] && [[ "$BRANCH_NAME" == "master" || "$BRA
                 fi
 
                 # Sync values from local to helm-chart repository
-                cp -f -r "./../kube/values/$APP_NAME/staging/$CURRENT_ENV/" "./staging/"
+                cp --force --recursive "./../kube/values/$APP_NAME/staging/$CURRENT_ENV/" "./staging/"
             fi
         else
             echo "$CURRENT_ENV not found in local code repository, but existing in helm-chart-$APP_NAME-values/staging repository."
         fi
     done
-    # Always sync values-stg.yaml when a Pull Request is closed
-    cp -f "./../kube/values/$APP_NAME/staging/values-stg.yaml" "./staging/values-stg.yaml"
+    # Always sync common values-stg.yaml when a Pull Request is closed
+    find "./../kube/values/$APP_NAME/staging/*" -maxdepth 1 -type f | xargs -I {} cp {} "./staging/"
     if [ ! -z ${synced_staging_envs+x} ]; then
         echo "synced_staging_envs=$( echo $synced_staging_envs )" >> $GITHUB_OUTPUT
     fi
@@ -97,7 +97,7 @@ if [[ "$ENV_TO_DEPLOY" == "ALL_ENV" ]] && [[ "$BRANCH_NAME" == "master" || "$BRA
 # Sync common staging values if deploying to 'ONLY_GLOBAL_STG_VALUES' on 'master' or 'main' branch
 elif [[ "$ENV_TO_DEPLOY" == "ONLY_COMMON_STG_VALUES" ]] && [[ "$BRANCH_NAME" == "master" || "$BRANCH_NAME" == "main" ]]; then
     cd helm-chart-$APP_NAME-values-staging/
-    cp -f "./../kube/values/$APP_NAME/staging/values-stg.yaml" "./staging/values-stg.yaml"
+    find "./../kube/values/$APP_NAME/staging/*" -maxdepth 1 -type f | xargs -I {} cp {} "./staging/"
 
 # Sync prod values if deploying to 'prod' on 'master' or 'main' branch
 elif [[ "$ENV_TO_DEPLOY" == "prod" ]] && [[ "$BRANCH_NAME" == "master" || "$BRANCH_NAME" == "main" ]]; then
@@ -110,7 +110,7 @@ elif [[ "$ENV_TO_DEPLOY" == "prod" ]] && [[ "$BRANCH_NAME" == "master" || "$BRAN
     if [ ! -z ${DEPLOYED_AT} ]; then
         sed -i "{s/DEPLOYED_AT:.*/DEPLOYED_AT: $DEPLOYED_AT/;}" "./../kube/values/$APP_NAME/prod/values-prod.yaml"
     fi
-    cp -f -r "./../kube/values/$APP_NAME/prod/" "./"
+    cp --force --recursive "./../kube/values/$APP_NAME/prod/" "./"
 
 # Sync prod values if deploying to 'prod' for a specific 'release version'
 elif [[ "$ENV_TO_DEPLOY" == "prod" ]] && [[ ! -z "$RELEASE_VERSION" ]]; then
@@ -121,7 +121,7 @@ elif [[ "$ENV_TO_DEPLOY" == "prod" ]] && [[ ! -z "$RELEASE_VERSION" ]]; then
     if [ ! -z ${DEPLOYED_AT} ]; then
         sed -i "{s/DEPLOYED_AT:.*/DEPLOYED_AT: $DEPLOYED_AT/;}" "./../kube/values/$APP_NAME/prod-$RELEASE_VERSION/values-prod.yaml"
     fi
-    cp -f -r "./../kube/values/$APP_NAME/prod-$RELEASE_VERSION/" "./"
+    cp --force --recursive "./../kube/values/$APP_NAME/prod-$RELEASE_VERSION/" "./"
 else
     cd helm-chart-$APP_NAME-values-staging/
     # Store the currentTag for potential rollback
@@ -132,7 +132,7 @@ else
     if [ ! -z ${DEPLOYED_AT} ]; then
         sed -i "{s/DEPLOYED_AT:.*/DEPLOYED_AT: $DEPLOYED_AT/;}" "./../kube/values/$APP_NAME/staging/$ENV_TO_DEPLOY/values-stg.yaml"
     fi
-    cp -f -r "./../kube/values/$APP_NAME/staging/$ENV_TO_DEPLOY/" "./staging/"
+    cp --force --recursive "./../kube/values/$APP_NAME/staging/$ENV_TO_DEPLOY/" "./staging/"
 fi
 
 # Check for changes and commit if there are any

--- a/.github/actions/argocd-deployment/update-chart-values/entrypoint.sh
+++ b/.github/actions/argocd-deployment/update-chart-values/entrypoint.sh
@@ -66,6 +66,11 @@ if [[ "$ENV_TO_DEPLOY" == "ALL_ENV" ]] && [[ "$BRANCH_NAME" == "master" || "$BRA
                     continue
                 fi
 
+                # Skip performance deployment if not required
+                if [[ $DEPLOY_ON_PERFORMANCE == false && "$CURRENT_ENV" == "performance" ]]; then
+                    continue
+                fi
+
                 # Update the currentTag if IMAGE_TAG is set
                 if [ "$IMAGE_TAG" != "" ]; then
                     sed -i "{s/currentTag:.*/currentTag: $IMAGE_TAG/;}" "./staging/$CURRENT_ENV/values-stg-tag.yaml"


### PR DESCRIPTION
##Issues:
1. https://app.shortcut.com/fcm-digital/story/26128/update-github-update-chart-values-to-sync-the-entire-common-staging-directory
2. https://app.shortcut.com/fcm-digital/story/27173/ignore-performance-env-during-syncing-staging-environments-when-a-pr-is-closed

##Solutions:
1. Use `find -maxdepth 1 -type f` instead of `cp` command.
2. Add new `deploy_on_performance` input to control performance syncing. False by default